### PR TITLE
refactor: Rewrote commands to support Mac in addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ are dumped in the `./tiles` folder as single MBTiles.
 In Ubuntu 24.04, the version of Tilemaker available is a bit outdated, as the
 3.0 version is a lot faster, so it's recommended to compile this yourself.
 
+> On Mac, [install dependencies and build tilemaker from source](https://github.com/systemed/tilemaker/blob/master/docs/INSTALL.md#macos)
+
 ### Martin
 
 [Martin](https://maplibre.org/martin/introduction.html) is a web server for
@@ -44,10 +46,14 @@ anywhere.
 Install using e.g. `cargo binstall martin --root=/usr/local`, assuming you have
 Rust's `cargo` and `cargo-binstall` installed.
 
+> On Mac, [install Martin using HomeBrew](https://maplibre.org/martin/installation.html#homebrew)
+
 A Systemd service file is provided to make martin a first-class service citizen
 in your system. Copy this to `/etc/systemd/system/`, customize it, then enable
 it with `systemctl enable martin` and finally run it with `service martin
 start`.
+
+You can also serve the tiles folder with Martin directly using `martin ./tiles`.
 
 ### Nginx
 
@@ -86,21 +92,14 @@ The styles are available directly from nginx, if `./public/` is set to your
 vhosts root. They have hardcoded values to tile server data, which must be
 changed (branched out) for your installation.
 
+If you prefer not to use `nginx`, you can host the `./public/` folder directly using your http-server of choice, e.g. `npx http-server --cors ./public` 
+
 ### Configs
 
 The `./etc` folder has all necessary configs used in this stack, and may be used
 directly on top of your system's `/etc` folder, if using \*NIX-alike OSes.
 
-## Running on Mac OS
+## Troubleshooting
 
-1. Install Martin using HomeBrew by running `brew tap maplibre/martin` and `brew install martin`.
-2. Install cUrl using HomeBrew by running `brew install curl-openssl`
-3. Install dependencies for `tilemaker` using `brew installx boost lua51 shapelib rapidjson`
-4. Clone the [tilemaker](https://github.com/systemed/tilemaker) repository, `cd` into it and run `make`
-5. Install it by running `sudo make install`
-
-_Now we can generate tiles using_ `./bin/gen-tiles.sh`
-
-6. Serve the generated tiles by running `martin ./tiles`
-> We need to enable CORS such that the Martin server can access our styles
-7. Serve styles from the `./public` folder with your http-server of choice, e.g. `npx http-server --cors ./public` 
+### curl: (4) A requested feature, protocol or option was not found built-in in this libcurl due to a build-time decision.
+This occurs on Mac if you do not have the correct `cUrl` installed. Ensure `cUrl` with `openssl` support is installed (`brew install curl-openssl`).

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Nginx is provided. Be aware that the CORS header allows running this from
 anywhere.
 
 Install using e.g. `cargo binstall martin --root=/usr/local`, assuming you have
-rust's `cargo` and `cargo-binstall` installed.
+Rust's `cargo` and `cargo-binstall` installed.
 
 A Systemd service file is provided to make martin a first-class service citizen
 in your system. Copy this to `/etc/systemd/system/`, customize it, then enable
@@ -90,3 +90,17 @@ changed (branched out) for your installation.
 
 The `./etc` folder has all necessary configs used in this stack, and may be used
 directly on top of your system's `/etc` folder, if using \*NIX-alike OSes.
+
+## Running on Mac OS
+
+1. Install Martin using HomeBrew by running `brew tap maplibre/martin` and `brew install martin`.
+2. Install cUrl using HomeBrew by running `brew install curl-openssl`
+3. Install dependencies for `tilemaker` using `brew installx boost lua51 shapelib rapidjson`
+4. Clone the [tilemaker](https://github.com/systemed/tilemaker) repository, `cd` into it and run `make`
+5. Install it by running `sudo make install`
+
+_Now we can generate tiles using_ `./bin/gen-tiles.sh`
+
+6. Serve the generated tiles by running `martin ./tiles`
+> We need to enable CORS such that the Martin server can access our styles
+7. Serve styles from the `./public` folder with your http-server of choice, e.g. `npx http-server --cors ./public` 

--- a/bin/gen-tiles.sh
+++ b/bin/gen-tiles.sh
@@ -153,7 +153,7 @@ function download_pbf {
     then
         echo "--- BEGIN osm download of $AREA"
         rm -f $PBF_DEST
-        curl -LSsf --output $PBF_DEST $PBF_URL
+        curl -sf --output $PBF_DEST $PBF_URL
         echo "--- END osm download of $AREA"
     else
         echo "Not downloading PBF of $AREA: File exists and is recent."
@@ -226,7 +226,7 @@ function finalize {
         mv -vf $MBTILES_SHADOW $MBTILES
     fi
     local SCRIPT_END=$(($(date +%s) - $SCRIPT_START))
-    local MBTILES_SIZE=$(stat -c %s $MBTILES)
+    local MBTILES_SIZE=$(wc -c < "$MBTILES" | tr -d ' ')
     echo
     echo "------------------------------------------------------------------------------"
     echo "Summary:"

--- a/tilemaker/get-coastline.sh
+++ b/tilemaker/get-coastline.sh
@@ -10,6 +10,6 @@ mkdir -p $DIR_TILEMAKER/coastline
 cd $DIR_TILEMAKER/coastline
 
 if ! [ -f "water-polygons-split-4326.zip" ]; then
-  curl --proto '=https' --tlsv1.3 -sSfO https://osmdata.openstreetmap.de/download/water-polygons-split-4326.zip
+  curl -sfO https://osmdata.openstreetmap.de/download/water-polygons-split-4326.zip
   unzip -o -j water-polygons-split-4326.zip
 fi

--- a/tilemaker/get-landcover.sh
+++ b/tilemaker/get-landcover.sh
@@ -10,19 +10,19 @@ mkdir -p $DIR_TILEMAKER/landcover
 cd $DIR_TILEMAKER/landcover
 
 if ! [ -f "ne_10m_antarctic_ice_shelves_polys.zip" ]; then
-    curl --proto '=https' --tlsv1.3 -sSfO https://naciscdn.org/naturalearth/10m/physical/ne_10m_antarctic_ice_shelves_polys.zip
+    curl -sfO https://naciscdn.org/naturalearth/10m/physical/ne_10m_antarctic_ice_shelves_polys.zip
     mkdir -p ne_10m_antarctic_ice_shelves_polys
     unzip -o ne_10m_antarctic_ice_shelves_polys.zip -d ne_10m_antarctic_ice_shelves_polys
 fi
 
 if ! [ -f "ne_10m_urban_areas.zip" ]; then
-    curl --proto '=https' --tlsv1.3 -sSfO https://naciscdn.org/naturalearth/10m/cultural/ne_10m_urban_areas.zip
+    curl -sfO https://naciscdn.org/naturalearth/10m/cultural/ne_10m_urban_areas.zip
     mkdir -p ne_10m_urban_areas
     unzip -o ne_10m_urban_areas.zip -d ne_10m_urban_areas
 fi
 
 if ! [ -f "ne_10m_glaciated_areas.zip" ]; then
-    curl --proto '=https' --tlsv1.3 -sSfO https://naciscdn.org/naturalearth/10m/physical/ne_10m_glaciated_areas.zip
+    curl -sfO https://naciscdn.org/naturalearth/10m/physical/ne_10m_glaciated_areas.zip
     mkdir -p ne_10m_glaciated_areas
     unzip -o ne_10m_glaciated_areas.zip -d ne_10m_glaciated_areas
 fi


### PR DESCRIPTION
Some `cUrl` options are not supported on Mac, but they did not seem to be essential to the script. 

Added documentation on how to set up for Mac.